### PR TITLE
Bump the setup-micromamba GH action

### DIFF
--- a/.github/workflows/check_new_templates.yml
+++ b/.github/workflows/check_new_templates.yml
@@ -31,7 +31,7 @@ jobs:
         git diff templates.smi
 
     - name: Set up Python & RDKit
-      uses: mamba-org/setup-micromamba@v1
+      uses: mamba-org/setup-micromamba@v2
       with:
         micromamba-version: 'latest'
         environment-file: environment.yml

--- a/.github/workflows/update_templates.yml
+++ b/.github/workflows/update_templates.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@v3
     - name: Set up Python & RDKit
-      uses: mamba-org/setup-micromamba@v1
+      uses: mamba-org/setup-micromamba@v2
       with:
         micromamba-version: 'latest'
         environment-file: environment.yml


### PR DESCRIPTION
We currently have the v1 version, which uses an obsoleted GH cache version. This updates to v2.