### PR TITLE
Make TEMPLATE_SMARTS a constexpr array

### DIFF
--- a/src/header_generation.py
+++ b/src/header_generation.py
@@ -9,7 +9,7 @@ from rdkit import Geometry
 HEADER_FILE = 'template_smarts.h'
 TEMPLATE_FILE = 'templates.smi'
 
-HEADER_TEXT = """//
+HEADER_TEXT_TPL = """//
 //  Copyright (C) 2023 Schrödinger, LLC
 //
 //   @@ All Rights Reserved @@
@@ -23,12 +23,12 @@ HEADER_TEXT = """//
 // templates, please refer to instructions in:
 // https://github.com/rdkit/molecular_templates/blob/main/README.md
 //
+//
 
-#include <string>
-#include <vector>
+#include <array>
 
 // clang-format off
-const std::vector<std::string> TEMPLATE_SMARTS = {
+inline constexpr std::array<const char*, {}> TEMPLATE_SMARTS = {{
 """
 
 
@@ -132,17 +132,17 @@ def mark_inner_atoms(smiles):
 
 
 def generate_header(generated_header_path):
+    smarts_lines = []
+    with open(TEMPLATE_FILE, 'r') as f_in:
+        for line in f_in:
+            if not (cxsmiles := line.strip()):
+                continue
+        # TO_DO: replace bonds with query bonds
+            cxsmiles = mark_inner_atoms(cxsmiles)
+            smarts_lines.append(f'    "{cxsmiles}",\n')
     with open(generated_header_path, 'w') as f_out:
-        f_out.write(HEADER_TEXT)
-        with open(TEMPLATE_FILE, 'r') as f_in:
-            for line in f_in:
-                if not (cxsmiles := line.strip()):
-                    continue
-
-            # TO_DO: replace bonds with query bonds
-                cxsmiles = mark_inner_atoms(cxsmiles)
-
-                f_out.write(f'    "{cxsmiles}",\n')
+        f_out.write(HEADER_TEXT_TPL.format(len(smarts_lines)))
+        f_out.writelines(''.join(smarts_lines))
         f_out.write('};\n// clang-format on\n')
     print(f"Successfully generated {generated_header_path}")
 


### PR DESCRIPTION
There are quite a few templates now. Since RDKit now supports `constexpr`, it would be nice to store `TEMPLATE_SMARTS` in a `constexpr std::array` instead of a `const std::vector`.

This requires a couple of changes in the header:
- `std::string` can't be `constexpr`, so we need to swap it out to `const char*`, which can be `constexpr`.
- The size of the array needs to be specified in the declaration, so we need to change the writing loop a bit so we can count how many templates we have.

These changes should be transparent to RDKit, so no further changes would be required there.

We should also trigger a CI run to have the header updated, and trigger an update on the RDKit side too.